### PR TITLE
Update apidoc.yml

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -56,6 +56,7 @@ jobs:
       # 문서 배포
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/api


### PR DESCRIPTION
apidoc이 빌드 실패하는 이유로 action 수정

## 참조
https://www.notion.so/Error-Action-failed-with-The-process-usr-bin-git-failed-with-exit-code-1-72da34536ba146d491e0931a33d1888e?pvs=4

## 리뷰 포인트


## 스크린 샷

