### PR TITLE
feat/ 유저 정보 읽기 기능 추가

### DIFF
--- a/src/router/user/index.ts
+++ b/src/router/user/index.ts
@@ -3,8 +3,38 @@ import Router from '@koa/router';
 import UserModel from '@/models/user';
 import AuthModel from '@/models/auth';
 import passport from 'koa-passport';
+import { isNil } from '@/utils';
 
 const user = new Router({ prefix: '/user' });
+/**
+ * @api {get} /user Get Account
+ * @apiDescription 계정 정보 요청
+ *
+ * @apiVersion 0.1.0
+ * @apiGroup User
+ * @apiHeader {String} authorization Bearer 토큰 스트링
+ * @apiSuccess {String} name 유저 이름
+ * @apiSuccess {String} email 유저 이메일
+ */
+user.get(
+  '/',
+  passport.authenticate('local', { session: false }),
+  async (ctx: Context) => {
+    const { email } = ctx.state.user;
+
+    const userData = await UserModel.read({ email });
+    if (isNil(userData)) {
+      ctx.throw(400, '유저 정보를 읽는데 실패함');
+    }
+
+    ctx.body = {
+      name: userData.name,
+      email,
+    };
+    ctx.status = 200;
+  }
+);
+
 /**
  * @api {delete} /user Delete Account
  * @apiDescription 계정 삭제 요청


### PR DESCRIPTION
## 리뷰 포인트


## 스크린 샷

![image](https://github.com/ganada-labs/nlog-BE/assets/40891497/fcee2299-2d15-49c1-b840-b84fef7c57b4)

이름과 이메일을 읽어옴

![image](https://github.com/ganada-labs/nlog-BE/assets/40891497/41a8913a-b0fa-4cb0-a466-f3c417120dd2)
계정을 삭제한 뒤 다시 요청하면 unauthorized가 뜸 (없는 계정을 읽을 수 없음)