### PR TITLE
#51/use corail to make declarative

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@koa/cors": "^4.0.0",
     "@koa/router": "^12.0.0",
+    "corail": "^0.2.8",
     "jsonwebtoken": "^9.0.1",
     "koa": "^2.14.2",
     "koa-passport": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   '@koa/router':
     specifier: ^12.0.0
     version: 12.0.0
+  corail:
+    specifier: ^0.2.8
+    version: 0.2.8
   jsonwebtoken:
     specifier: ^9.0.1
     version: 9.0.1
@@ -1887,6 +1890,10 @@ packages:
     dependencies:
       depd: 2.0.0
       keygrip: 1.1.0
+    dev: false
+
+  /corail@0.2.8:
+    resolution: {integrity: sha512-091CiDl3aGORtF4SPQwqHfLPwWGlwHJ4hvlnMVc+nDxdgPTrVbfa10GQ6Hid3Wu6y7vl8E0yPBZvWLs2XEzAwA==}
     dev: false
 
   /create-require@1.1.1:

--- a/src/domains/auth.ts
+++ b/src/domains/auth.ts
@@ -1,0 +1,69 @@
+import corail from 'corail';
+
+import TokenModel from '@/models/auth';
+import { isNil, type, token as Token } from '@/utils';
+import { StatusError } from '@/utils/error';
+
+export type TokenPayload = { email: string; provider: string };
+export type TokenInfo = TokenPayload & {
+  token: string;
+};
+
+export const isUnusedToken = async (tokenInfo: TokenInfo) => {
+  const savedToken = await TokenModel.get({ email: tokenInfo.email });
+
+  if (isNil(savedToken) || tokenInfo.token !== savedToken) {
+    throw new StatusError(403, '탈취된 토큰');
+  }
+
+  return tokenInfo;
+};
+
+export const verifyToken = (token: string) => {
+  const decoded = Token.verify(token);
+
+  if (type.isString(decoded)) {
+    throw new StatusError(401, `토큰이 잘못됨: ${decoded}`);
+  }
+
+  if (isNil(decoded.email) || isNil(decoded.provider)) {
+    throw new StatusError(401, '토큰에 필요한 정보가 포함되지 않음');
+  }
+
+  return {
+    token,
+    email: decoded.email,
+    provider: decoded.provider,
+  };
+};
+
+export const extractToken = (authorization: string) => {
+  const token = Token.getBearerCredential(authorization);
+  if (token === '') {
+    throw new StatusError(401, '토큰이 없음');
+  }
+  return token;
+};
+
+export const generateTokens = (email: string, provider: string) =>
+  Token.genTokens({ email, provider });
+
+export const saveToken = async (email: string, token: string) => {
+  await TokenModel.set({ email }, token);
+};
+
+export const verifyRefreshToken = async (
+  authorization?: string
+): Promise<StatusError | TokenInfo> => {
+  const result = await corail.railRight(
+    isUnusedToken,
+    verifyToken,
+    extractToken
+  )(authorization);
+
+  if (corail.isFailed(result)) {
+    return result.err;
+  }
+
+  return result;
+};

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,15 @@
+export type Status = 200 | 401 | 403;
+
+// 불변 객체
+export class StatusError extends Error {
+  #status: Status;
+
+  constructor(status: Status, message: string) {
+    super(message);
+    this.#status = status;
+  }
+
+  get status() {
+    return this.#status;
+  }
+}

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -6,7 +6,8 @@ export const REFRESH_TOKEN_EXPIRES_IN = '14d';
 const JWT_SECRET: jwt.Secret = import.meta.env.VITE_JWT_SECRET ?? 'my_secret';
 
 export type TokenPayload = string | object | Buffer;
-export type TokenDecoded = string | jwt.Jwt | jwt.JwtPayload;
+export type TokenSuccessDecoded = jwt.JwtPayload;
+export type TokenDecoded = string | TokenSuccessDecoded;
 
 const genToken = (payload: TokenPayload, options?: jwt.SignOptions) =>
   jwt.sign(payload, JWT_SECRET, options);


### PR DESCRIPTION
## 리뷰 포인트
- corail을 이용해 선언형으로 코드를 변경 
- domain 폴더 생성 및 auth 도메인 코드를 이동
- 아직 refresh 요청에 대해서만 적용, 운용하다 이상 없으면 차차 corail의 이용을 늘려나갈 것
- auth 도메인도 마찬가지로 다른 auth 관련 흩어져 있는 로직을 모아 적용할 것

## 스크린 샷

