### PR TITLE
update/ check refresh token from cookie

### DIFF
--- a/src/domains/auth/index.ts
+++ b/src/domains/auth/index.ts
@@ -48,8 +48,7 @@ export const verifyRefreshToken = (refreshToken: string) => {
   };
 };
 
-export const extractToken = (authorization: string) => {
-  const refreshToken = token.getBearerCredential(authorization);
+export const isRefreshTokenExist = (refreshToken?: string) => {
   if (refreshToken === '') {
     throw new StatusError(401, '토큰이 없음');
   }
@@ -81,13 +80,13 @@ export const saveToken = async (email: string, refreshToken: string) => {
 };
 
 export const checkAuthorization = async (
-  authorization?: string
+  refreshToken?: string
 ): Promise<StatusError | TokenInfo> => {
   const result = await corail.railRight(
     isUnusedToken,
     verifyRefreshToken,
-    extractToken
-  )(authorization);
+    isRefreshTokenExist
+  )(refreshToken);
 
   if (corail.isFailed(result)) {
     return result.err;

--- a/src/router/auth/google.ts
+++ b/src/router/auth/google.ts
@@ -82,6 +82,7 @@ GoogleAuth.get(
       httpOnly: true,
       domain: DOMAIN,
       maxAge: Auth.REFRESH_TOKEN_EXPIRES_IN,
+      path: '/auth/refresh',
     });
 
     ctx.redirect(OAUTH_REDIRECT_URL);


### PR DESCRIPTION
## 리뷰 포인트
- refresh는 authorization 헤더가 아닌 cookie에서 읽어오도록 수정함
- auth/refresh 경로인 경우에만 refresh_token 쿠키를 보내도록 설정함

## 스크린 샷

