### PR TITLE
update/ cookie의 maxAge 설정을 밀리초 단위로 수행하도록 변경

### DIFF
--- a/src/router/auth/google.ts
+++ b/src/router/auth/google.ts
@@ -84,7 +84,7 @@ GoogleAuth.get(
     ctx.cookies.set('refresh_token', refreshToken, {
       httpOnly: true,
       domain: DOMAIN,
-      maxAge: Auth.REFRESH_TOKEN_EXPIRES_IN,
+      maxAge: Auth.REFRESH_TOKEN_EXPIRES_IN * 1000,
       sameSite: 'strict',
       path: '/',
     });

--- a/src/router/auth/index.ts
+++ b/src/router/auth/index.ts
@@ -42,7 +42,7 @@ auth.get('/refresh', checkRefreshCredential, async (ctx: Context) => {
   ctx.cookies.set('refresh_token', refreshToken, {
     httpOnly: true,
     domain: DOMAIN,
-    maxAge: Auth.REFRESH_TOKEN_EXPIRES_IN,
+    maxAge: Auth.REFRESH_TOKEN_EXPIRES_IN * 1000,
     sameSite: 'strict',
     path: '/',
   });


### PR DESCRIPTION
## 리뷰 포인트
- 쿠키의 maxAge 값을 초 단위에서 밀리초 단위로 수정함

## 스크린 샷

