### PR TITLE
feat/ post요청시 토큰이 있다면, 토큰을 통해 이메일을 얻고, 포스트 작성자인지 비교함

### DIFF
--- a/src/router/post/index.ts
+++ b/src/router/post/index.ts
@@ -16,8 +16,10 @@ import {
   updatePost2,
   updateTitle,
 } from '@/services/post';
+import * as Auth from '@/services/auth';
 import corail from '@/packages/corail';
 import { StatusError } from '@/utils/error';
+import { isNil, isString } from '@/utils';
 
 type PostQuery = {
   author?: PostSchema['meta']['author'];
@@ -50,8 +52,23 @@ post.get('/:id', async (ctx: Context) => {
 
   const { post: targetPost } = result;
 
+  const token = Auth.getBearerCredential(ctx.request.header.authorization);
+  const decoded = Auth.decodeAccessToken(token);
+
+  let isAuthor = false;
+  if (
+    !isString(decoded) &&
+    !isNil(decoded.email) &&
+    decoded.email === targetPost.meta?.author
+  ) {
+    isAuthor = true;
+  }
+
   ctx.status = 200;
-  ctx.body = targetPost;
+  ctx.body = {
+    isAuthor,
+    post: targetPost,
+  };
 });
 
 /**


### PR DESCRIPTION
## 리뷰 포인트

- 토큰 존재시 토큰을 읽고 이메일을 획득, 이메일로 포스트의 작성자인지 확인, isAuthor boolean 값을 설정해서 반환
- 작성자인지 파악하는 코드는 자주 사용될 것이므로 나중에 미들웨어로 분리하는 것이 좋아 보임

## 스크린 샷

